### PR TITLE
feat: Add self-hosted openfire initially

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@
 
 ### VisualStudioCode ###
 .vscode/
+
+### Generated files
+# openfire
+/openfire/
+
+# mysql
+/db/data/
+
+### Sensitive or high-churn files
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-# ref. Dockerを使ってMySQLの環境を構築してみました
-# https://zenn.dev/bloomer/articles/7c879ab2a67abc
-FROM mysql:8.0-debian
-RUN apt-get update && \
-    apt-get install -y locales
-RUN locale-gen ja_JP.UTF-8
-RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8
-ENV LANG=ja_JP.UTF-8
-ENV TZ=Asia/Tokyo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# ref. Dockerを使ってMySQLの環境を構築してみました
+# https://zenn.dev/bloomer/articles/7c879ab2a67abc
+FROM mysql:8.0-debian
+RUN apt-get update && \
+    apt-get install -y locales
+RUN locale-gen ja_JP.UTF-8
+RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8
+ENV LANG=ja_JP.UTF-8
+ENV TZ=Asia/Tokyo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,7 @@ services:
 #      OPENFIRE_AUTH_PROVIDER_PROP_HOST: ${OPENFIRE_AUTH_PROVIDER_PROP
   db:
     container_name: openfire-db
-    build: .
-    platform: linux/amd64
+    image: mysql:8.4.0
     ports:
       - 3307:3306
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  openfire:
+    container_name: self-hosted-openfire
+    image: nasqueron/openfire:4.8.0
+    platform: linux/amd64
+    ports:
+      - 9090:9090
+      - 5222:5222
+      - 7777:7777
+    volumes:
+      - ./openfire:/var/lib/openfire
+    depends_on:
+      - db
+    restart: always
+# TODO Consider the following description examples
+#    volumes:
+#      - ./openfire/conf:/usr/share/openfire/conf
+#      - ./openfire/plugins:/usr/share/openfire/plugins
+#      - ./openfire/resources/security:/usr/share/openfire/resources/security
+#      - ./openfire/resources/database:/usr/share/openfire/resources/database
+#    environment:
+#      OPENFIRE_DB_HOST: ${OPENFIRE_DB_HOST}
+#      OPENFIRE_DB_PORT: ${OPENFIRE_DB_PORT}
+#      OPENFIRE_DB_NAME: ${OPENFIRE_DB_NAME}
+#      OPENFIRE_DB_USER: ${OPENFIRE_DB_USER}
+#      OPENFIRE_DB_PASSWORD: ${OPENFIRE_DB_PASSWORD}
+#      OPENFIRE_ADMIN_USER: ${OPENFIRE_ADMIN_USER}
+#      OPENFIRE_ADMIN_PASSWORD: ${OPENFIRE_ADMIN_PASSWORD}
+#      OPENFIRE_DOMAIN: ${OPENFIRE_DOMAIN}
+#      OPENFIRE_HOSTNAME: ${OPENFIRE_HOSTNAME}
+#      OPENFIRE_PORT: ${OPENFIRE_PORT}
+#      OPENFIRE_SECURE_PORT: ${OPENFIRE_SECURE_PORT}
+#      OPENFIRE_RESOURCE: ${OPENFIRE_RESOURCE}
+#      OPENFIRE_AUTH_PROVIDER: ${OPENFIRE_AUTH_PROVIDER}
+#      OPENFIRE_AUTH_PROVIDER_PROP: ${OPENFIRE_AUTH_PROVIDER_PROP}
+#      OPENFIRE_AUTH_PROVIDER_PROP_KEY: ${OPENFIRE_AUTH_PROVIDER_PROP_KEY}
+#      OPENFIRE_AUTH_PROVIDER_PROP_SECRET: ${OPENFIRE_AUTH_PROVIDER_PROP_SECRET}
+#      OPENFIRE_AUTH_PROVIDER_PROP_URL: ${OPENFIRE_AUTH_PROVIDER_PROP_URL}
+#      OPENFIRE_AUTH_PROVIDER_PROP_HOST: ${OPENFIRE_AUTH_PROVIDER_PROP
+  db:
+    container_name: openfire-db
+    build: .
+    platform: linux/amd64
+    ports:
+      - 3307:3306
+    volumes:
+      - ./db/data:/var/lib/mysql
+    environment:
+      # TODO Thinking other ways
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,31 +12,6 @@ services:
     depends_on:
       - db
     restart: unless-stopped
-# TODO Consider the following description examples
-#    volumes:
-#      - ./openfire/conf:/usr/share/openfire/conf
-#      - ./openfire/plugins:/usr/share/openfire/plugins
-#      - ./openfire/resources/security:/usr/share/openfire/resources/security
-#      - ./openfire/resources/database:/usr/share/openfire/resources/database
-#    environment:
-#      OPENFIRE_DB_HOST: ${OPENFIRE_DB_HOST}
-#      OPENFIRE_DB_PORT: ${OPENFIRE_DB_PORT}
-#      OPENFIRE_DB_NAME: ${OPENFIRE_DB_NAME}
-#      OPENFIRE_DB_USER: ${OPENFIRE_DB_USER}
-#      OPENFIRE_DB_PASSWORD: ${OPENFIRE_DB_PASSWORD}
-#      OPENFIRE_ADMIN_USER: ${OPENFIRE_ADMIN_USER}
-#      OPENFIRE_ADMIN_PASSWORD: ${OPENFIRE_ADMIN_PASSWORD}
-#      OPENFIRE_DOMAIN: ${OPENFIRE_DOMAIN}
-#      OPENFIRE_HOSTNAME: ${OPENFIRE_HOSTNAME}
-#      OPENFIRE_PORT: ${OPENFIRE_PORT}
-#      OPENFIRE_SECURE_PORT: ${OPENFIRE_SECURE_PORT}
-#      OPENFIRE_RESOURCE: ${OPENFIRE_RESOURCE}
-#      OPENFIRE_AUTH_PROVIDER: ${OPENFIRE_AUTH_PROVIDER}
-#      OPENFIRE_AUTH_PROVIDER_PROP: ${OPENFIRE_AUTH_PROVIDER_PROP}
-#      OPENFIRE_AUTH_PROVIDER_PROP_KEY: ${OPENFIRE_AUTH_PROVIDER_PROP_KEY}
-#      OPENFIRE_AUTH_PROVIDER_PROP_SECRET: ${OPENFIRE_AUTH_PROVIDER_PROP_SECRET}
-#      OPENFIRE_AUTH_PROVIDER_PROP_URL: ${OPENFIRE_AUTH_PROVIDER_PROP_URL}
-#      OPENFIRE_AUTH_PROVIDER_PROP_HOST: ${OPENFIRE_AUTH_PROVIDER_PROP
   db:
     container_name: openfire-db
     image: mysql:8.4.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     volumes:
       - ./db/data:/var/lib/mysql
     environment:
-      # TODO Thinking other ways
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - ./openfire:/var/lib/openfire
     depends_on:
       - db
-    restart: always
+    restart: unless-stopped
 # TODO Consider the following description examples
 #    volumes:
 #      - ./openfire/conf:/usr/share/openfire/conf
@@ -51,3 +51,4 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Adding initial support for a Docker-based, self-hosted Openfire server with a MySQL database.

## Description

- This repository uses the Openfire image that seems to be reliable and fresh for building containers.
- **This** Openfire uses locally built MySQL, not the embedded DB.

## Additional Notes

- 💡 For future work, I am planning to configure Openfire to connect to MySQL when Docker starts.
